### PR TITLE
Adds media-mtxt to library config.

### DIFF
--- a/config/library_code_translations.rb
+++ b/config/library_code_translations.rb
@@ -28,6 +28,7 @@ module LibraryCodeTranslations
   "JACKSON" => "Business",
   "MATH-CS" => "Math & Statistics",
   "MEYER" => "Meyer",
+  "MEDIA-MTXT" => "Media & Microtext Center",
   "MUSIC" => "Music",
   #"PHYSICS" => "Physics", No longer a library
   "SAL" => "SAL1&2 (on-campus shelving)",


### PR DESCRIPTION
@lmcglohon Please review and merge. The ckey 7682116 wasn't showing up in the media microtext library facet without adding a library code translation for MEDIA-MTXT. The ckey with its course reserve items show up in the correct facet on morison: http://searchworks-test.stanford.edu/morison/?f%5Bbuilding_facet%5D%5B%5D=Media+%26+Microtext+Center&f%5Bformat_main_ssim%5D%5B%5D=Video&q=imitation+of+life&search_field=search
