### PR TITLE
Adds new Science Library reserve locations

### DIFF
--- a/config/library_code_translations.rb
+++ b/config/library_code_translations.rb
@@ -33,6 +33,7 @@ module LibraryCodeTranslations
   "SAL" => "SAL1&2 (on-campus shelving)",
   "SAL3" => "SAL3 (off-campus storage)",
   'SAL-NEWARK' => "SAL Newark (off-campus storage)",
+  "SCIENCE" => "Science (Li and Ma)",
   "SPEC-COLL" => "Special Collections",
   #SPEC-DESK => "(In-transit location for SAL paged items)",
   "TANNER" => "Philosophy (Tanner)"

--- a/config/rez_desk_translations.rb
+++ b/config/rez_desk_translations.rb
@@ -22,6 +22,7 @@ module RezDeskTranslations
     "MEYER-RESV" => "Meyer",
     "MUSIC-RESV" => "Music",
 #    "PHYS-RESV" => "Physics", No longer a Physics library
+    "SCI-RESV" => "Science (Li and Ma)",
     "TANN-RESV" => "Philosophy (Tanner)"
   }
 
@@ -46,6 +47,7 @@ module RezDeskTranslations
     "MEYER-RESV" => "Meyer Reserves",
     "MUSIC-RESV" => "Music Reserves",
     #"PHYS-RESV" => "Physics Reserves", No longer a Physics library
+    "SCI-RESV" => "Science Reserves",
     "TANN-RESV" => "Tanner Reserves"
   }
 


### PR DESCRIPTION
@lmcglohon Please review and merge when you get a chance. Some test data with course reserves have been indexed on morison: http://searchworks-test.stanford.edu/morison/?f%5Bbuilding_facet%5D%5B%5D=Science+%28Li+and+Ma%29
